### PR TITLE
Include check for existence of proximityUUID

### DIFF
--- a/RNBeacon.m
+++ b/RNBeacon.m
@@ -232,6 +232,10 @@ RCT_EXPORT_METHOD(shouldDropEmptyRanges:(BOOL)drop)
 
 -(void)locationManager:(CLLocationManager *)manager
         didEnterRegion:(CLBeaconRegion *)region {
+    if (! [region respondsToSelector:@selector(proximityUUID)]) {
+        return;
+    }
+
     NSDictionary *event = @{
                             @"region": region.identifier,
                             @"uuid": [region.proximityUUID UUIDString],
@@ -242,6 +246,10 @@ RCT_EXPORT_METHOD(shouldDropEmptyRanges:(BOOL)drop)
 
 -(void)locationManager:(CLLocationManager *)manager
          didExitRegion:(CLBeaconRegion *)region {
+    if (! [region respondsToSelector:@selector(proximityUUID)]) {
+        return;
+    }
+
     NSDictionary *event = @{
                             @"region": region.identifier,
                             @"uuid": [region.proximityUUID UUIDString],


### PR DESCRIPTION
Using the library together with the `react-native-background-geolocation` throws an error described in [this issue](https://github.com/frostney/react-native-ibeacon/issues/35). This PR fixes that error by applying the solution described in the comment.